### PR TITLE
Add Bootstrap to project files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App.js';
+import { Tooltip, Toast, Popover } from 'bootstrap';
+import Alert from 'bootstrap/js/dist/alert';
 // Require Sass file so webpack can build it
 import 'bootstrap/dist/css/bootstrap.css';
 import './styles/style.css';


### PR DESCRIPTION
This adds Bootstrap to the project files so webpack can pick up on them.

### Working alert closure:
![Aug-31-2021 04-41-23](https://user-images.githubusercontent.com/2329654/131496398-003d22a4-200c-4900-a2c8-8eec772e28ee.gif)

### Working off canvas profile:
![Aug-31-2021 04-41-32](https://user-images.githubusercontent.com/2329654/131496407-299afb0d-d958-4ffe-b1d5-863ca300f400.gif)
